### PR TITLE
Add alerts dropdown to metrics section

### DIFF
--- a/torchci/components/NavBar.tsx
+++ b/torchci/components/NavBar.tsx
@@ -102,6 +102,17 @@ function NavBar() {
     },
   ];
 
+  const metricsDropdown = [
+    {
+      name: "Metrics",
+      href: "/metrics",
+    },
+    {
+      name: "Alerts",
+      href: "/alerts",
+    },
+  ];
+
   return (
     <div className={styles.navbar}>
       <div>
@@ -150,11 +161,7 @@ function NavBar() {
               Requests
             </Link>
           </li>
-          <li>
-            <Link prefetch={false} href="/metrics">
-              Metrics
-            </Link>
-          </li>
+          <NavBarDropdown title="Metrics" items={metricsDropdown} />
           <li>
             <Link prefetch={false} href="/kpis">
               KPIs

--- a/torchci/pages/alerts.tsx
+++ b/torchci/pages/alerts.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const AlertsPage = () => {
+  return (
+    <div style={{ width: '100vw', height: '100vh', margin: 0, padding: 0 }}>
+      <iframe
+        src="https://pytorchci.grafana.net/public-dashboards/500bf186083048f39940617a80b57fd1"
+        style={{ width: '100%', height: '100%', border: 'none' }}
+        title="Alerts Dashboard"
+      />
+    </div>
+  );
+};
+
+export default AlertsPage;


### PR DESCRIPTION
Add a dropdown menu for the "Metrics" section in the top bar and create a new "Alerts" page.

* Change the "Metrics" link in `torchci/components/NavBar.tsx` to a dropdown menu with two items: "Metrics" and "Alerts".
* Set the href of the "Metrics" item to "/metrics" and the href of the "Alerts" item to "/alerts".
* Add a new page component in `torchci/pages/alerts.tsx` that renders a fullscreen Grafana iframe with the src set to "https://pytorchci.grafana.net/public-dashboards/500bf186083048f39940617a80b57fd1".
* Add necessary styling to make the iframe fullscreen.

